### PR TITLE
fix: update broken urls

### DIFF
--- a/components/common/footer.tsx
+++ b/components/common/footer.tsx
@@ -50,11 +50,14 @@ export default function Footer() {
 
         <div className="flex flex-col gap-2">
           <h3 className="text-lg font-bold">Documentation</h3>
-          <Item link={'https://docs.openlit.io/latest/introduction'} text="Introduction" />
-          <Item link={'https://docs.openlit.io/latest/installation'} text="Installation" />
-          <Item link={'https://docs.openlit.io/latest/configuration'} text="Configuration" />
+          <Item link={'https://docs.openlit.io/latest/overview'} text="Introduction" />
+          <Item link={'https://docs.openlit.io/latest/openlit/installation'} text="Installation" />
           <Item
-            link={'https://docs.openlit.io/latest/integrations/introduction'}
+            link={'https://docs.openlit.io/latest/openlit/configuration'}
+            text="Configuration"
+          />
+          <Item
+            link={'https://docs.openlit.io/latest/sdk/integrations/overview'}
             text="Integrations"
           />
         </div>

--- a/components/home/hero.tsx
+++ b/components/home/hero.tsx
@@ -46,7 +46,7 @@ export default function Hero() {
           <GitHubLogoIcon className="ml-2 h-5 w-5" />
         </a> */}
         <a
-          href="https://docs.openlit.io/latest/introduction"
+          href="https://docs.openlit.io/latest/overview"
           target="_blank"
           className={`group relative z-10 flex items-center justify-center space-x-2 rounded-full border border-transparent bg-transparent px-4 py-2 text-sm font-medium text-black transition duration-200 hover:bg-gray-100 dark:text-white dark:hover:bg-neutral-800 dark:hover:shadow-xl md:text-sm`}
         >


### PR DESCRIPTION
Some links on the OpenLint main website were leading to 404 pages.  

<img width="1369" height="789" alt="Screenshot 2025-10-07 at 3 29 10 PM" src="https://github.com/user-attachments/assets/78763fea-c5c6-4e1b-b4a2-d9a11f28f07d" />

This PR fixes the broken links by updating them to the correct URLs, ensuring all links navigate properly.